### PR TITLE
fix `Field.__init__`

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -539,6 +539,8 @@ class Field(Criterion, JSON):
     ) -> None:
         super().__init__(alias=alias)
         self.name = name
+        if isinstance(table, str):
+            table = Table(table)
         self.table = table
 
     def nodes_(self) -> Iterator[NodeT]:


### PR DESCRIPTION
According to the signature of `Field.__init__`, arguemant `table` could be `str` type.
According to the signature of Field.__init__, the argument table can be of type str. Therefore, we should also check the type and ensure that self.table is assigned a Table object.